### PR TITLE
Balance & Fixes

### DIFF
--- a/src/BM2/SiteBundle/Controller/ActionsController.php
+++ b/src/BM2/SiteBundle/Controller/ActionsController.php
@@ -943,9 +943,8 @@ class ActionsController extends Controller {
 				if ($soldier->getCharacter() && $soldier->getCharacter()->isInBattle()) continue;
 				if ($soldier->getCharacter() && $soldier->getCharacter()->isDoingAction('military.regroup')) continue;
 				// FIXME: can't recall from your own estates or characters, but there should also be a message:
-				//if ($soldier->getCharacter() && $soldier->getCharacter()->getUser() == $character->getUser()) continue;
-				//if ($soldier->getBase() && $soldier->getBase()->getOwner() && $soldier->getBase()->getOwner()->getUser() == $character->getUser()) continue;
-				// Currently interferes with recalling soldiers from Knights who accept offers and run off.
+				// if ($soldier->getCharacter() && $soldier->getCharacter()->getUser() == $character->getUser()) continue;
+				// if ($soldier->getBase() && $soldier->getBase()->getOwner() && $soldier->getBase()->getOwner()->getUser() == $character->getUser()) continue;
 
 				if ($soldier->getAssignedSince() == -1) {
 					$days = 0;

--- a/src/BM2/SiteBundle/Controller/ActionsController.php
+++ b/src/BM2/SiteBundle/Controller/ActionsController.php
@@ -943,8 +943,9 @@ class ActionsController extends Controller {
 				if ($soldier->getCharacter() && $soldier->getCharacter()->isInBattle()) continue;
 				if ($soldier->getCharacter() && $soldier->getCharacter()->isDoingAction('military.regroup')) continue;
 				// FIXME: can't recall from your own estates or characters, but there should also be a message:
-				if ($soldier->getCharacter() && $soldier->getCharacter()->getUser() == $character->getUser()) continue;
-				if ($soldier->getBase() && $soldier->getBase()->getOwner() && $soldier->getBase()->getOwner()->getUser() == $character->getUser()) continue;
+				//if ($soldier->getCharacter() && $soldier->getCharacter()->getUser() == $character->getUser()) continue;
+				//if ($soldier->getBase() && $soldier->getBase()->getOwner() && $soldier->getBase()->getOwner()->getUser() == $character->getUser()) continue;
+				// Currently interferes with recalling soldiers from Knights who accept offers and run off.
 
 				if ($soldier->getAssignedSince() == -1) {
 					$days = 0;

--- a/src/BM2/SiteBundle/DataFixtures/ORM/LoadEquipmentData.php
+++ b/src/BM2/SiteBundle/DataFixtures/ORM/LoadEquipmentData.php
@@ -12,12 +12,12 @@ use BM2\SiteBundle\Entity\EquipmentType;
 class LoadEquipmentData extends AbstractFixture implements OrderedFixtureInterface {
 
 	private $equipment = array(
-		'axe'               => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  10, 'defense' =>   0, 'train' => 20, 'resupply' => 20,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/streitaxt2.png'),
-		'spear'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  20, 'defense' =>   0, 'train' => 30, 'resupply' => 30,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/spear2.png'),
-		'pike'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  30, 'defense' =>   0, 'train' => 50, 'resupply' => 60,	'provider' => 'Weaponsmith',  'trainer' => 'Guardhouse',				'icon' => 'items/hellebarde2.png'),
-		'mace'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  35, 'defense' =>   0, 'train' => 60, 'resupply' =>100,	'provider' => 'Weaponsmith',  'trainer' => 'Barracks',				'icon' => 'items/hellebarde2.png'),
-		'sword'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  45, 'defense' =>   0, 'train' => 80, 'resupply' =>250,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/schwert2.png'),
-		'broadsword'        => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  50, 'defense' =>   0, 'train' => 90, 'resupply' =>350,	'provider' => 'Bladesmith', 'trainer' => 'Garrison',					'icon' => 'items/claymore2.png'),
+		'axe'               => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  15, 'defense' =>   0, 'train' => 20, 'resupply' => 20,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/streitaxt2.png'),
+		'spear'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  35, 'defense' =>   0, 'train' => 30, 'resupply' => 30,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/spear2.png'),
+		'pike'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  50, 'defense' =>   0, 'train' => 50, 'resupply' => 60,	'provider' => 'Weaponsmith',  'trainer' => 'Guardhouse',				'icon' => 'items/hellebarde2.png'),
+		'mace'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  65, 'defense' =>   0, 'train' => 60, 'resupply' =>100,	'provider' => 'Weaponsmith',  'trainer' => 'Barracks',				'icon' => 'items/hellebarde2.png'),
+		'sword'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  85, 'defense' =>   0, 'train' => 80, 'resupply' =>250,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/schwert2.png'),
+		'broadsword'        => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  95, 'defense' =>   0, 'train' => 90, 'resupply' =>350,	'provider' => 'Bladesmith', 'trainer' => 'Garrison',					'icon' => 'items/claymore2.png'),
 
 		'shortbow'          => array('type' => 'weapon',    'ranged' => 40, 'melee' =>   0, 'defense' =>   0, 'train' => 50, 'resupply' => 50,	'provider' => 'Bowyer',      'trainer' => 'Archery Range',			'icon' => 'items/shortbow2.png'),
 		'crossbow'          => array('type' => 'weapon',    'ranged' => 60, 'melee' =>   0, 'defense' =>   0, 'train' => 60, 'resupply' => 75,	'provider' => 'Bowyer',      'trainer' => 'Archery Range',			'icon' => 'items/armbrust2.png'),
@@ -31,9 +31,10 @@ class LoadEquipmentData extends AbstractFixture implements OrderedFixtureInterfa
 		'plate armour'      => array('type' => 'armour',    'ranged' =>  0, 'melee' =>   0, 'defense' =>  80, 'train' => 80, 'resupply' =>500,	'provider' => 'Heavy Armourer',	'trainer' => 'Wood Castle',		'icon' => 'items/plattenpanzer2.png'),
 
 		'horse'             => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  20, 'defense' =>  20, 'train' => 60, 'resupply' =>300,	'provider' => 'Stables',     'trainer' => 'Barracks',					'icon' => 'items/packpferd2.png'),
-		'war horse'         => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  25, 'defense' =>  30, 'train' =>100, 'resupply' =>800,	'provider' => 'Royal Mews',  'trainer' => 'Wood Castle',				'icon' => 'items/warhorse2.png'),
-		'shield'            => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>   0, 'defense' =>  25, 'train' => 40, 'resupply' => 40,	'provider' => 'Carpenter',   'trainer' => 'Guardhouse',				'icon' => 'items/shield2.png'),
+		'war horse'         => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  35, 'defense' =>  40, 'train' =>100, 'resupply' =>800,	'provider' => 'Royal Mews',  'trainer' => 'Wood Castle',				'icon' => 'items/warhorse2.png'),
+		'shield'            => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>   0, 'defense' =>  30, 'train' => 40, 'resupply' => 40,	'provider' => 'Carpenter',   'trainer' => 'Guardhouse',				'icon' => 'items/shield2.png'),
 		'javelin'           => array('type' => 'equipment', 'ranged' => 65, 'melee' =>  10, 'defense' =>   0, 'train' => 40, 'resupply' => 35,	'provider' => 'Weaponsmith', 'trainer' => 'Guardhouse',				'icon' => 'items/javelin2.png'),
+		// Why does Javelin have a melee bonus?
 		'short sword'       => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  10, 'defense' =>   5, 'train' => 40, 'resupply' => 50,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/kurzschwert2.png'),
 	);
 

--- a/src/BM2/SiteBundle/DataFixtures/ORM/LoadEquipmentData.php
+++ b/src/BM2/SiteBundle/DataFixtures/ORM/LoadEquipmentData.php
@@ -12,12 +12,12 @@ use BM2\SiteBundle\Entity\EquipmentType;
 class LoadEquipmentData extends AbstractFixture implements OrderedFixtureInterface {
 
 	private $equipment = array(
-		'axe'               => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  15, 'defense' =>   0, 'train' => 20, 'resupply' => 20,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/streitaxt2.png'),
-		'spear'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  35, 'defense' =>   0, 'train' => 30, 'resupply' => 30,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/spear2.png'),
-		'pike'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  50, 'defense' =>   0, 'train' => 50, 'resupply' => 60,	'provider' => 'Weaponsmith',  'trainer' => 'Guardhouse',				'icon' => 'items/hellebarde2.png'),
+		'axe'               => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  10, 'defense' =>   0, 'train' => 20, 'resupply' => 20,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/streitaxt2.png'),
+		'spear'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  20, 'defense' =>   0, 'train' => 30, 'resupply' => 30,	'provider' => 'Blacksmith',  'trainer' => 'Training Ground',		'icon' => 'items/spear2.png'),
+		'pike'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  40, 'defense' =>   0, 'train' => 50, 'resupply' => 60,	'provider' => 'Weaponsmith',  'trainer' => 'Guardhouse',				'icon' => 'items/hellebarde2.png'),
 		'mace'              => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  65, 'defense' =>   0, 'train' => 60, 'resupply' =>100,	'provider' => 'Weaponsmith',  'trainer' => 'Barracks',				'icon' => 'items/hellebarde2.png'),
-		'sword'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  85, 'defense' =>   0, 'train' => 80, 'resupply' =>250,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/schwert2.png'),
-		'broadsword'        => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  95, 'defense' =>   0, 'train' => 90, 'resupply' =>350,	'provider' => 'Bladesmith', 'trainer' => 'Garrison',					'icon' => 'items/claymore2.png'),
+		'sword'             => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  75, 'defense' =>   0, 'train' => 80, 'resupply' =>250,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/schwert2.png'),
+		'broadsword'        => array('type' => 'weapon',    'ranged' =>  0, 'melee' =>  90, 'defense' =>   0, 'train' => 90, 'resupply' =>350,	'provider' => 'Bladesmith', 'trainer' => 'Garrison',					'icon' => 'items/claymore2.png'),
 
 		'shortbow'          => array('type' => 'weapon',    'ranged' => 40, 'melee' =>   0, 'defense' =>   0, 'train' => 50, 'resupply' => 50,	'provider' => 'Bowyer',      'trainer' => 'Archery Range',			'icon' => 'items/shortbow2.png'),
 		'crossbow'          => array('type' => 'weapon',    'ranged' => 60, 'melee' =>   0, 'defense' =>   0, 'train' => 60, 'resupply' => 75,	'provider' => 'Bowyer',      'trainer' => 'Archery Range',			'icon' => 'items/armbrust2.png'),
@@ -31,10 +31,9 @@ class LoadEquipmentData extends AbstractFixture implements OrderedFixtureInterfa
 		'plate armour'      => array('type' => 'armour',    'ranged' =>  0, 'melee' =>   0, 'defense' =>  80, 'train' => 80, 'resupply' =>500,	'provider' => 'Heavy Armourer',	'trainer' => 'Wood Castle',		'icon' => 'items/plattenpanzer2.png'),
 
 		'horse'             => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  20, 'defense' =>  20, 'train' => 60, 'resupply' =>300,	'provider' => 'Stables',     'trainer' => 'Barracks',					'icon' => 'items/packpferd2.png'),
-		'war horse'         => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  35, 'defense' =>  40, 'train' =>100, 'resupply' =>800,	'provider' => 'Royal Mews',  'trainer' => 'Wood Castle',				'icon' => 'items/warhorse2.png'),
-		'shield'            => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>   0, 'defense' =>  30, 'train' => 40, 'resupply' => 40,	'provider' => 'Carpenter',   'trainer' => 'Guardhouse',				'icon' => 'items/shield2.png'),
+		'war horse'         => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  25, 'defense' =>  30, 'train' =>100, 'resupply' =>800,	'provider' => 'Royal Mews',  'trainer' => 'Wood Castle',				'icon' => 'items/warhorse2.png'),
+		'shield'            => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>   0, 'defense' =>  25, 'train' => 40, 'resupply' => 40,	'provider' => 'Carpenter',   'trainer' => 'Guardhouse',				'icon' => 'items/shield2.png'),
 		'javelin'           => array('type' => 'equipment', 'ranged' => 65, 'melee' =>  10, 'defense' =>   0, 'train' => 40, 'resupply' => 35,	'provider' => 'Weaponsmith', 'trainer' => 'Guardhouse',				'icon' => 'items/javelin2.png'),
-		// Why does Javelin have a melee bonus?
 		'short sword'       => array('type' => 'equipment', 'ranged' =>  0, 'melee' =>  10, 'defense' =>   5, 'train' => 40, 'resupply' => 50,	'provider' => 'Bladesmith', 'trainer' => 'Barracks',					'icon' => 'items/kurzschwert2.png'),
 	);
 

--- a/src/BM2/SiteBundle/Entity/Soldier.php
+++ b/src/BM2/SiteBundle/Entity/Soldier.php
@@ -150,7 +150,8 @@ class Soldier extends NPC {
 			case 'light cavalry':
 			case 'heavy cavalry':		return 4;
 			case 'mounted archer':		return 3;
-			case 'archer':					return 2;
+			case 'armoured archer':     return 3;
+			case 'archer':				return 2;
 			case 'heavy infantry':		return 3;
 			case 'medium infantry':		return 2;
 			case 'light infantry':

--- a/src/BM2/SiteBundle/Service/Economy.php
+++ b/src/BM2/SiteBundle/Service/Economy.php
@@ -556,7 +556,7 @@ class Economy {
 			if ($force_recalc) {
 				list($building_resource, $building_bonus) = $this->ResourceFromBuildings($settlement, $resource, $baseresource);
 				$georesource->setBuildingsBase($building_resource);
-				$georesource->setBuildingsBonus(round($building_bonus*100));
+				$georesource->setBuildingsBonus(round($building_bonus*10));
 			} else {
 				$building_resource = $georesource->getBuildingsBase();
 				$building_bonus = $georesource->getBuildingsBonus()/10;
@@ -627,7 +627,7 @@ class Economy {
 			$base += $result->getProvidesOperation();
 			$bonus+= $result->getProvidesOperationBonus();
 		}
-		return array($base, 1.0+($bonus/100));
+		return array($base, 1.0+($bonus/10));
 	}
 
 	public function ResourceDemand(Settlement $settlement, ResourceType $resource, $split_results=false) {

--- a/src/BM2/SiteBundle/Service/Economy.php
+++ b/src/BM2/SiteBundle/Service/Economy.php
@@ -559,7 +559,7 @@ class Economy {
 				$georesource->setBuildingsBonus(round($building_bonus*100));
 			} else {
 				$building_resource = $georesource->getBuildingsBase();
-				$building_bonus = $georesource->getBuildingsBonus()/100;
+				$building_bonus = $georesource->getBuildingsBonus()/10;
 			}
 		}
 		$baseresource += $building_resource;


### PR DESCRIPTION
Fixed balance on weapons, so that they are more 1:1 ratio with defense.
Adjusted shields and war horses. Removed a potential exploit fix, which
interfered with recalling soldiers from Knights who ran off, but
prevented players from recalling their own troops. Additionally, changed the bonus from buildings calculation by 10fold. I ran some initial simulation, but the conclusion is not to the test is not very clear, as I lacked a good simulation for geological data. Economy might have to be reverted quickly.
