### PR TITLE
Allow realms to restore abandoned subrealms

### DIFF
--- a/app/Resources/FOSUserBundle/views/Registration/register.html.twig
+++ b/app/Resources/FOSUserBundle/views/Registration/register.html.twig
@@ -8,7 +8,7 @@
 <div id="direct_register">
 	<p>{{ 'registration.direct'|trans|raw }}</p>
 	<br />
-	<form action="{{ path('fos_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="wide fos_user_registration_register">
+	<form action="{{ path('fos_user_registration_register') }}" {{ form_start(form) }} method="POST" class="wide fos_user_registration_register">
 		{{ form_widget(form) }}
 		<div id="feedback" class="warning" style="display:none"></div>
 		<button name="register_submit">{{ 'registration.submit'|trans({}, 'FOSUserBundle') }}</button>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -105,7 +105,7 @@ services:
 
     bm2.user_manager:
         class:      BM2\SiteBundle\Service\UserManager
-        arguments:  [@doctrine.orm.entity_manager, %fos_user.model.user.class%, @security.encoder_factory, @fos_user.util.username_canonicalizer, @fos_user.util.email_canonicalizer]
+        arguments:  [@doctrine.orm.entity_manager, %fos_user.model.user.class%, @fos_user.util.password_updater, @fos_user.util.canonical_fields_updater]
     payment_manager:
         class:      BM2\SiteBundle\Service\PaymentManager
         arguments:  [@doctrine.orm.entity_manager, @bm2.user_manager, @mailer, @translator, @logger]

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/doctrine-fixtures-bundle": "dev-master",
         "friendsofsymfony/user-bundle": "~2.0@dev",
         "creof/doctrine2-spatial": "dev-master",
-        "knplabs/knp-markdown-bundle": "1.2.*@dev",
+        "knplabs/knp-markdown-bundle": "1.4.*@dev",
         "codeception/codeception": "*",
         "paypal/merchant-sdk-php":"*"
     },

--- a/src/BM2/DungeonBundle/DataFixtures/ORM/LoadDungeonCards.php
+++ b/src/BM2/DungeonBundle/DataFixtures/ORM/LoadDungeonCards.php
@@ -27,7 +27,7 @@ class LoadDungeonCards extends AbstractFixture implements OrderedFixtureInterfac
 		'fight.strong'		=> array('rarity' =>  500, 'monsterclass'=> '', 'target'=>array('monster'=>true, 'treasure'=>false, 'dungeoneer'=>false)),
 		'fight.hit'		=> array('rarity' =>  500, 'monsterclass'=> '', 'target'=>array('monster'=>true, 'treasure'=>false, 'dungeoneer'=>false)),
 		'fight.weak'		=> array('rarity' =>  650, 'monsterclass'=> '', 'target'=>array('monster'=>true, 'treasure'=>false, 'dungeoneer'=>false)),
-		'fight.slime'		=> array('rarity' =>  550, 'monsterclass'=> 'slime', 'target'=>array('monster'=>true, 'treasure'=>false, 'dungeoneer'=>false))
+		'fight.slime'		=> array('rarity' =>  550, 'monsterclass'=> 'slime', 'target'=>array('monster'=>true, 'treasure'=>false, 'dungeoneer'=>false)),
 
 
 		// uncommon cards

--- a/src/BM2/DungeonBundle/DataFixtures/ORM/LoadDungeonMonsters.php
+++ b/src/BM2/DungeonBundle/DataFixtures/ORM/LoadDungeonMonsters.php
@@ -19,14 +19,14 @@ class LoadDungeonMonsters extends AbstractFixture implements OrderedFixtureInter
 		'bear'		=> array('power' => 50, 'attacks' =>  1, 'defense' => 25, 'wounds' => 2, 'mindepth' => 0, 'class' => array('animal', 'melee', 'solo'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'lab', 'glade')),
 		'cat'		=> array('power' => 40, 'attacks' =>  1, 'defense' => 20, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'solo', 'stealth'), 'areas' => array('wild', 'ruin', 'glade', 'lab', 'shipgrave')),
 		'eagle'		=> array('power' => 40, 'attacks' =>  1, 'defense' => 25, 'wounds' => 2, 'mindepth' => 1, 'class' => array('animal', 'fly', 'melee'), 'areas' => array('wild', 'ruin', 'glade', 'lab')),
-		'mongrel'	=> array('power' => 20, 'attacks' =>  1, 'defense' => 10, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'solo', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'glade', 'citadel', 'hold', 'lab', 'mausoleum', 'flooded', 'shipgrave'))
+		'mongrel'	=> array('power' => 20, 'attacks' =>  1, 'defense' => 10, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'solo', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'glade', 'citadel', 'hold', 'lab', 'mausoleum', 'flooded', 'shipgrave')),
 		'rat'		=> array('power' =>  5, 'attacks' =>  1, 'defense' =>  5, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'swim', 'melee'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'glade', 'citadel', 'hold', 'lab', 'roguefort', 'mausoleum', 'flooded', 'shipgrave')),
 		'snake'		=> array('power' => 30, 'attacks' =>  1, 'defense' => 10, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'melee', 'poison'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'lab', 'glade', 'mausoleum', 'flooded')),
-		'wolf'		=> array('power' => 25, 'attacks' =>  1, 'defense' => 20, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'ruin',, 'lab', 'flooded')),
+		'wolf'		=> array('power' => 25, 'attacks' =>  1, 'defense' => 20, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'ruin', 'lab', 'flooded')),
 		'wolfb'		=> array('power' => 60, 'attacks' =>  1, 'defense' => 40, 'wounds' => 2, 'mindepth' => 1, 'class' => array('animal', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'dungeon', 'citadel', 'lab', 'flooded')),
 
 		// beasts
-		'dog'		=> array('power' => 45, 'attacks' =>  1, 'defense' => 15, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'solo', 'melee'), 'areas' => array('cave', 'ruin', 'dungeon', 'citadel', 'hold', 'roguefort', 'lab'))
+		'dog'		=> array('power' => 45, 'attacks' =>  1, 'defense' => 15, 'wounds' => 1, 'mindepth' => 0, 'class' => array('animal', 'solo', 'melee'), 'areas' => array('cave', 'ruin', 'dungeon', 'citadel', 'hold', 'roguefort', 'lab')),
 		'falcon'	=> array('power' => 25, 'attacks' =>  1, 'defense' => 10, 'wounds' => 2, 'mindepth' => 1, 'class' => array('animal', 'fly', 'melee'), 'areas' => array('wild', 'ruin', 'glade', 'lab', 'citadel', 'roguefort', 'flooded', 'shipgrave')),
 		'hawk'		=> array('power' => 40, 'attacks' =>  1, 'defense' => 25, 'wounds' => 2, 'mindepth' => 2, 'class' => array('animal', 'fly', 'melee'), 'areas' => array('wild', 'ruin', 'glade', 'lab', 'flooded', 'shipgrave')),
 		
@@ -38,30 +38,30 @@ class LoadDungeonMonsters extends AbstractFixture implements OrderedFixtureInter
 		'crazy'		=> array('power' => 20, 'attacks' =>  1, 'defense' => 20, 'wounds' => 1, 'mindepth' => 0, 'class' => array('human', 'melee'), 'areas' => array('cave', 'ruin', 'dungeon', 'lab', 'wild', 'glade', 'mausoleum', 'flooded', 'shipgrave')),
 		'monhunter'	=> array('power' => 90, 'attacks' =>  1, 'defense' => 45, 'wounds' => 2, 'mindepth' => 4, 'class' => array('human', 'ranged', 'group', 'swim', 'poison'), 'areas' => array('cave', 'ruin', 'dungeon', 'lab', 'wild', 'glade', 'citadel', 'mausoleum', 'flooded', 'shipgrave')),
 		'npcdungeoneer'	=> array('power' => 65, 'attacks' =>  1, 'defense' => 80, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee', 'group', 'swim'), 'areas' => array('cave', 'ruin', 'dungeon', 'lab', 'wild', 'glade', 'citadel', 'mausoleum', 'flooded', 'shipgrave')),
-		'shaman'	=> array('power' => 30, 'attacks' =>  3, 'defense' => 40, 'wounds' => 2, 'mindepth' => 3, 'class' => array('human', 'mixed', 'swim', 'solo'), 'areas' => array('cave', 'dungeon', 'ruin', 'glade', 'lab', 'wild', 'citadel', 'hold', 'mausoleum', 'flooded', 'shipgrave'))
+		'shaman'	=> array('power' => 30, 'attacks' =>  3, 'defense' => 40, 'wounds' => 2, 'mindepth' => 3, 'class' => array('human', 'mixed', 'swim', 'solo'), 'areas' => array('cave', 'dungeon', 'ruin', 'glade', 'lab', 'wild', 'citadel', 'hold', 'mausoleum', 'flooded', 'shipgrave')),
 		'lost'		=> array('power' => 80, 'attacks' =>  2, 'defense' => 80, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee', 'solo'), 'areas' => array('ruin', 'dungeon', 'hold', 'citadel', 'glade', 'lab', 'mausoleum', 'flooded', 'shipgrave')),
 		'villager'	=> array('power' => 15, 'attacks' =>  1, 'defense' => 15, 'wounds' => 1, 'mindepth' => 0, 'class' => array('human', 'melee', 'swim'), 'areas' => array('cave', 'ruin', 'dungeon', 'hold', 'citadel', 'lab', 'mausoleum', 'flooded', 'shipgrave')),
 		
 		// monsters
 		'barghest'	=> array('power' => 90, 'attacks' =>  1, 'defense' => 50, 'wounds' => 3, 'mindepth' => 3, 'class' => array('monster', 'melee'), 'areas' => array('cave', 'dungeon', 'citadel', 'glade', 'lab', 'mausoleum', 'shipgrave')),
-		'chimera'	=> array('power' => 75, 'attacks' =>  3, 'defense' => 45, 'wounds' => 3, 'mindepth' => 4, 'class' => array('monster', 'mixed', 'fly', 'swim', 'poison', 'solo'), 'areas' => array('cave', 'lab', 'wild', 'citadel', 'glade', 'dungeon', 'mausoleum', 'shipgrave'))
-		'dragon'	=> array('power' =>250, 'attacks' =>  3, 'defense' =>150, 'wounds' => 6, 'mindepth' => 8, 'class' => array('monster', 'solo', 'mixed', 'fly', 'swim', 'boss'), 'areas' => array('cave', 'lab', 'dungeon', 'citadel'))
+		'chimera'	=> array('power' => 75, 'attacks' =>  3, 'defense' => 45, 'wounds' => 3, 'mindepth' => 4, 'class' => array('monster', 'mixed', 'fly', 'swim', 'poison', 'solo'), 'areas' => array('cave', 'lab', 'wild', 'citadel', 'glade', 'dungeon', 'mausoleum', 'shipgrave')),
+		'dragon'	=> array('power' =>250, 'attacks' =>  3, 'defense' =>150, 'wounds' => 6, 'mindepth' => 8, 'class' => array('monster', 'solo', 'mixed', 'fly', 'swim', 'boss'), 'areas' => array('cave', 'lab', 'dungeon', 'citadel')),
 		'ogre'		=> array('power' => 80, 'attacks' =>  1, 'defense' => 60, 'wounds' => 4, 'mindepth' => 4, 'class' => array('monster', 'melee'), 'areas' => array('ruin', 'dungeon', 'lab', 'shipgrave')),
 		'slime'		=> array('power' =>  5, 'attacks' =>  1, 'defense' =>  1, 'wounds' => 6, 'mindepth' => 0, 'class' => array('monster', 'slime', 'melee', 'pack'), 'areas' => array('cave', 'wild', 'ruin', 'dungeon', 'glade', 'citadel', 'hold', 'lab', 'roguefort', 'mausoleum', 'flooded', 'shipgrave')),
 		'troglodyte'	=> array('power' => 80, 'attacks' =>  2, 'defense' => 50, 'wounds' => 3, 'mindepth' => 4, 'class' => array('monster', 'melee'), 'areas' => array('cave', 'wild', 'lab', 'flooded', 'shipgrave')),
 		'wyvern'	=> array('power' =>150, 'attacks' =>  2, 'defense' => 80, 'wounds' => 2, 'mindepth' => 5, 'class' => array('monster', 'fly'), 'areas' => array('wild', 'lab', 'flooded', 'shipgrave')),
 	
 		// Rogue Fortress
-		'fortguard'	=> array('power' => 30, 'attacks' =>  1, 'defense' => 30, 'wounds' => 1, 'mindepth' => 0, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab'))
-		'fortguarda'	=> array('power' => 45, 'attacks' =>  1, 'defense' => 30, 'wounds' => 1, 'mindepth' => 1, 'class' => array('human', 'ranged'), 'areas' => array('roguefort', 'lab'))
-		'fortguardc'	=> array('power' => 75, 'attacks' =>  2, 'defense' => 35, 'wounds' => 4, 'mindepth' => 5, 'class' => array('human', 'melee', 'indiv'), 'areas' => array('roguefort', 'lab'))
-		'fortguardh'	=> array('power' => 40, 'attacks' =>  1, 'defense' => 80, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab'))
-		'fortguardv'	=> array('power' => 60, 'attacks' =>  2, 'defense' => 60, 'wounds' => 3, 'mindepth' => 3, 'class' => array('human', 'mixed', 'solo'), 'areas' => array('roguefort', 'lab'))
-		'fortguardhv'	=> array('power' => 90, 'attacks' =>  2, 'defense' => 80, 'wounds' => 4, 'mindepth' => 6, 'class' => array('human', 'mixed', 'indiv'), 'areas' => array('roguefort', 'lab'))
-		'fortcavalry'	=> array('power' => 35, 'attacks' =>  2, 'defense' => 40, 'wounds' => 2, 'mindepth' => 1, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab'))
-		'fortcavalryc'	=> array('power' => 90, 'attacks' =>  2, 'defense' => 45, 'wounds' => 4, 'mindepth' => 5, 'class' => array('human', 'mixed', 'mounted'), 'areas' => array('roguefort', 'lab'))
-		'fortcavalryh'	=> array('power' => 50, 'attacks' =>  2, 'defense' => 85, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee', 'mounted'), 'areas' => array('roguefort', 'lab'))
-		'fortcavalrya'	=> array('power' => 30, 'attacks' =>  2, 'defense' => 30, 'wounds' => 2, 'mindepth' => 2, 'class' => array('human', 'ranged', 'mounted,'), 'areas' => array('roguefort', 'lab'))
+		'fortguard'	=> array('power' => 30, 'attacks' =>  1, 'defense' => 30, 'wounds' => 1, 'mindepth' => 0, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab')),
+		'fortguarda'	=> array('power' => 45, 'attacks' =>  1, 'defense' => 30, 'wounds' => 1, 'mindepth' => 1, 'class' => array('human', 'ranged'), 'areas' => array('roguefort', 'lab')),
+		'fortguardc'	=> array('power' => 75, 'attacks' =>  2, 'defense' => 35, 'wounds' => 4, 'mindepth' => 5, 'class' => array('human', 'melee', 'indiv'), 'areas' => array('roguefort', 'lab')),
+		'fortguardh'	=> array('power' => 40, 'attacks' =>  1, 'defense' => 80, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab')),
+		'fortguardv'	=> array('power' => 60, 'attacks' =>  2, 'defense' => 60, 'wounds' => 3, 'mindepth' => 3, 'class' => array('human', 'mixed', 'solo'), 'areas' => array('roguefort', 'lab')),
+		'fortguardhv'	=> array('power' => 90, 'attacks' =>  2, 'defense' => 80, 'wounds' => 4, 'mindepth' => 6, 'class' => array('human', 'mixed', 'indiv'), 'areas' => array('roguefort', 'lab')),
+		'fortcavalry'	=> array('power' => 35, 'attacks' =>  2, 'defense' => 40, 'wounds' => 2, 'mindepth' => 1, 'class' => array('human', 'melee'), 'areas' => array('roguefort', 'lab')),
+		'fortcavalryc'	=> array('power' => 90, 'attacks' =>  2, 'defense' => 45, 'wounds' => 4, 'mindepth' => 5, 'class' => array('human', 'mixed', 'mounted'), 'areas' => array('roguefort', 'lab')),
+		'fortcavalryh'	=> array('power' => 50, 'attacks' =>  2, 'defense' => 85, 'wounds' => 3, 'mindepth' => 4, 'class' => array('human', 'melee', 'mounted'), 'areas' => array('roguefort', 'lab')),
+		'fortcavalrya'	=> array('power' => 30, 'attacks' =>  2, 'defense' => 30, 'wounds' => 2, 'mindepth' => 2, 'class' => array('human', 'ranged', 'mounted,'), 'areas' => array('roguefort', 'lab')),
 		'fortlesslord'	=> array('power' => 80, 'attacks' =>  3, 'defense' => 80, 'wounds' => 6, 'mindepth' => 6, 'class' => array('human', 'mixed', 'solo'), 'areas' => array('roguefort')),
 		'fortlord'	=> array('power' => 95, 'attacks' =>  4, 'defense' => 95, 'wounds' => 9, 'mindepth' => 8, 'class' => array('human', 'mixed', 'indiv', 'boss'), 'areas' => array('roguefort')),
 	);

--- a/src/BM2/DungeonBundle/Form/CardSelectType.php
+++ b/src/BM2/DungeonBundle/Form/CardSelectType.php
@@ -4,7 +4,7 @@ namespace BM2\DungeonBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 
 class CardSelectType extends AbstractType {
@@ -13,7 +13,7 @@ class CardSelectType extends AbstractType {
 		return 'cardselect';
 	}
 
-	public function configureOptions(OptionsResolverInterface $resolver) {
+	public function configureOptions(OptionsResolver $resolver) {
 		$resolver->setDefaults(array(
 			'intention'       	=> 'cardselect_136',
 			'translation_domain' => 'dungeons'

--- a/src/BM2/DungeonBundle/Form/ChatType.php
+++ b/src/BM2/DungeonBundle/Form/ChatType.php
@@ -4,7 +4,7 @@ namespace BM2\DungeonBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 
 
@@ -14,7 +14,7 @@ class ChatType extends AbstractType {
 		return 'chat';
 	}
 
-	public function configureOptions(OptionsResolverInterface $resolver) {
+	public function configureOptions(OptionsResolver $resolver) {
 		$resolver->setDefaults(array(
 			'intention'       	=> 'chat_14',
 			'data_class'			=> 'BM2\DungeonBundle\Entity\DungeonMessage',

--- a/src/BM2/DungeonBundle/Form/TargetSelectType.php
+++ b/src/BM2/DungeonBundle/Form/TargetSelectType.php
@@ -4,7 +4,7 @@ namespace BM2\DungeonBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 
 class TargetSelectType extends AbstractType {
@@ -23,7 +23,7 @@ class TargetSelectType extends AbstractType {
 		return 'target_'.$this->type;
 	}
 
-	public function configureOptions(OptionsResolverInterface $resolver) {
+	public function configureOptions(OptionsResolver $resolver) {
 		$resolver->setDefaults(array(
 			'intention'       	=> 'targetselect_513',
 			'translation_domain' => 'dungeons',

--- a/src/BM2/DungeonBundle/Resources/config/routing.yml
+++ b/src/BM2/DungeonBundle/Resources/config/routing.yml
@@ -3,6 +3,6 @@ dungeons:
     type:     annotation
     prefix:   /{_locale}
     requirements:
-     _locale: en|de|fr|it|pt|ru|sv|no|da|lv
+     _locale: en|de|fr|it|es|ru
     defaults:
      _locale: en

--- a/src/BM2/SiteBundle/Controller/ActionsController.php
+++ b/src/BM2/SiteBundle/Controller/ActionsController.php
@@ -184,7 +184,7 @@ class ActionsController extends Controller {
 	  * @Template
 	  */
 	public function exitAction() {
-		list($character, $settlement) = $this->get('dispatcher')->gateway('locationExitTest', true, true);
+		list($character, $settlement) = $this->get('dispatcher')->gateway('locationLeaveTest', true, true);
 
 		$result = null;
 		if ($this->get('interactions')->characterLeaveSettlement($character)) {

--- a/src/BM2/SiteBundle/Controller/ActionsController.php
+++ b/src/BM2/SiteBundle/Controller/ActionsController.php
@@ -179,6 +179,24 @@ class ActionsController extends Controller {
 		return array('settlement'=>$settlement, 'result'=>$result);
 	}
 
+	/**
+	  * @Route("/exit")
+	  * @Template
+	  */
+	public function exitAction() {
+		list($character, $settlement) = $this->get('dispatcher')->gateway('locationExitTest', true, true);
+
+		$result = null;
+		if ($this->get('interactions')->characterLeaveSettlement($character)) {
+			$result = 'left';
+		} else {
+			$result = 'denied';
+		}
+
+		$this->getDoctrine()->getManager()->flush();
+		return array('settlement'=>$settlement, 'result'=>$result);
+	}
+
    /**
      * @Route("/embark")
      * @Template

--- a/src/BM2/SiteBundle/Controller/NewsController.php
+++ b/src/BM2/SiteBundle/Controller/NewsController.php
@@ -41,7 +41,7 @@ class NewsController extends Controller {
 	}
 
 	/**
-	  * @Route("/read/{id}", requirements={"id"="\d+"})
+	  * @Route("/read/{id}", name="bm2_site_news_read", requirements={"id"="\d+"})
 	  * @Template
 	  */
 	public function readAction(NewsEdition $edition, Request $request) {

--- a/src/BM2/SiteBundle/Controller/NewsController.php
+++ b/src/BM2/SiteBundle/Controller/NewsController.php
@@ -41,7 +41,7 @@ class NewsController extends Controller {
 	}
 
 	/**
-	  * @Route("/read/{edition}", requirements={"edition"="\d+"})
+	  * @Route("/read/{id}", requirements={"id"="\d+"})
 	  * @Template
 	  */
 	public function readAction(NewsEdition $edition, Request $request) {

--- a/src/BM2/SiteBundle/Controller/NewsController.php
+++ b/src/BM2/SiteBundle/Controller/NewsController.php
@@ -41,7 +41,7 @@ class NewsController extends Controller {
 	}
 
 	/**
-	  * @Route("/read/{id}", name="bm2_site_news_read", requirements={"id"="\d+"})
+	  * @Route("/read/{edition}", name="bm2_site_news_read", requirements={"edition"="\d+"})
 	  * @Template
 	  */
 	public function readAction(NewsEdition $edition, Request $request) {

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -63,7 +63,7 @@ class RealmController extends Controller {
 	  */
 	public function viewAction(Realm $id) {
 		$realm = $id;
-		$character = $this->get('appstate')->getCharacter(true, true, true);
+		$character = $this->get('appstate')->getCharacter(false, true, true);
 
 		$territory = $realm->findTerritory();
 		$population = 0;

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -598,30 +598,30 @@ class RealmController extends Controller {
 		);
 	}
 
-#	/**
-#	  * @Route("/{realm}/restore", requirements={"realm"="\d+"})
-#	  * @Template
-#	  */
-#
-#	public function restoreAction(Realm $realm, Request $request) {
-#		$character = $this->gateway($realm, 'diplomacyRestoreTest');
-#		
-#		$form = $this->createForm(new RealmRestoreType($realm));
-#		$form->handleRequest($request);
-#		if ($form->isValid()) {
-#		    $data = $form->getData();
-#           $fail = false;
-#
-#            if (!$fail) {
-#                $this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
-#            }
-#
-#			$em = $this->getDoctrine()->getManager();
-#			$em->flush();
-#			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));
-#			return $this->redirectToRoute('bm2_site_realm_diplomacy', array('realm'=>$realm->getId()));
-#		}
-#	}
+	/**
+	  * @Route("/{realm}/restore", requirements={"realm"="\d+"})
+	  * @Template
+	  */
+
+	public function restoreAction(Realm $realm, Request $request) {
+		$character = $this->gateway($realm, 'diplomacyRestoreTest');
+		
+		$form = $this->createForm(new RealmRestoreType($realm));
+		$form->handleRequest($request);
+		if ($form->isValid()) {
+			$data = $form->getData();
+			$fail = false;
+
+			if (!$fail) {
+                		$this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
+            		}
+
+			$em = $this->getDoctrine()->getManager();
+			$em->flush();
+			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));
+			return $this->redirectToRoute('bm2_site_realm_diplomacy', array('realm'=>$realm->getId()));
+		}
+	}
 
 	/**
 	  * @Route("/{realm}/break", requirements={"realm"="\d+"})

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -14,6 +14,7 @@ use BM2\SiteBundle\Form\RealmManageType;
 use BM2\SiteBundle\Form\RealmOfficialsType;
 use BM2\SiteBundle\Form\RealmPositionType;
 use BM2\SiteBundle\Form\RealmRelationType;
+use BM2\SiteBundle\Form\RealmRestoreType;
 use BM2\SiteBundle\Form\RealmSelectType;
 use BM2\SiteBundle\Form\SubrealmType;
 use BM2\SiteBundle\Service\History;
@@ -595,6 +596,17 @@ class RealmController extends Controller {
 			'realmpoly' =>	$this->get('geography')->findRealmPolygon($realm),
 			'form' => $form->createView()
 		);
+	}
+
+	/**
+	  * @Route("/{realm}/restore", requirements={"realm"="\d+"})
+	  * @Template
+	  */
+
+	public function restoreAction(Realm $realm, Request $request) {
+		$character = $this->gateway($realm, 'diplomacyRestoreTest');
+		
+		if 
 	}
 
 	/**

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -609,7 +609,13 @@ class RealmController extends Controller {
 		$form = $this->createForm(new RestoreType($realm));
 		$form->handleRequest($request);
 		if ($form->isValid()) {
-			$this->get('realm_manager')->restoreSubRealm($realm, $deadrealm, $character);
+		    $data = $form->getData();
+            $fail = false;
+
+            if (!$fail) {
+                $this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
+            }
+
 			$em = $this->getDoctrine()->getManager();
 			$em->flush();
 			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -606,7 +606,15 @@ class RealmController extends Controller {
 	public function restoreAction(Realm $realm, Request $request) {
 		$character = $this->gateway($realm, 'diplomacyRestoreTest');
 		
-		if 
+		$form = $this->createForm(new RestoreType($realm));
+		$form->handleRequest($request);
+		if ($form->isValid()) {
+			$this->get('realm_manager')->restoreSubRealm($realm, $deadrealm, $character);
+			$em = $this->getDoctrine()->getManager();
+			$em->flush();
+			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));
+			return $this->redirectToRoute('bm2_site_realm_diplomacy', array('realm'=>$realm->getId()));
+		}
 	}
 
 	/**

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -598,26 +598,30 @@ class RealmController extends Controller {
 		);
 	}
 
-	/**
-	  * @Route("/{realm}/restore", requirements={"realm"="\d+"})
-	  * @Template
-	  */
-
-	public function restoreAction(Realm $realm, Request $request) {
-		$character = $this->gateway($realm, 'diplomacyRestoreTest');
-		
-		$form = $this->createForm(new RealmRestoreType($realm));
-		$form->handleRequest($request);
-		if ($form->isValid()) {
-			$data = $form->getData();
-               		$this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
-            		
-			$em = $this->getDoctrine()->getManager();
-			$em->flush();
-			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));
-			return $this->redirectToRoute('bm2_site_realm_diplomacy', array('realm'=>$realm->getId()));
-		}
-	}
+#	/**
+#	  * @Route("/{realm}/restore", requirements={"realm"="\d+"})
+#	  * @Template
+#	  */
+#
+#	public function restoreAction(Realm $realm, Request $request) {
+#		$character = $this->gateway($realm, 'diplomacyRestoreTest');
+#		
+#		$form = $this->createForm(new RealmRestoreType($realm));
+#		$form->handleRequest($request);
+#		if ($form->isValid()) {
+#		    $data = $form->getData();
+#           $fail = false;
+#
+#            if (!$fail) {
+#                $this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
+#            }
+#
+#			$em = $this->getDoctrine()->getManager();
+#			$em->flush();
+#			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));
+#			return $this->redirectToRoute('bm2_site_realm_diplomacy', array('realm'=>$realm->getId()));
+#		}
+#	}
 
 	/**
 	  * @Route("/{realm}/break", requirements={"realm"="\d+"})

--- a/src/BM2/SiteBundle/Controller/RealmController.php
+++ b/src/BM2/SiteBundle/Controller/RealmController.php
@@ -606,16 +606,12 @@ class RealmController extends Controller {
 	public function restoreAction(Realm $realm, Request $request) {
 		$character = $this->gateway($realm, 'diplomacyRestoreTest');
 		
-		$form = $this->createForm(new RestoreType($realm));
+		$form = $this->createForm(new RealmRestoreType($realm));
 		$form->handleRequest($request);
 		if ($form->isValid()) {
-		    $data = $form->getData();
-            $fail = false;
-
-            if (!$fail) {
-                $this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
-            }
-
+			$data = $form->getData();
+               		$this->get('realm_manager')->restoreSubRealm($realm, $deadrealm['deadrealm'], $character);
+            		
 			$em = $this->getDoctrine()->getManager();
 			$em->flush();
 			$this->addFlash('notice', $this->get('translator')->trans('diplomacy.restore.success', array(), 'politics'));

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -123,7 +123,7 @@ class Realm {
 	
 	public function findDeadInferiors() {
 		$all = new ArrayCollection;
-		foreach ($this->getInferiors() as $subrealms) {
+		foreach ($this->getInferiors() as $subrealm) {
 			if (!$subrealm->getActive()) {
 			$all->add($subrealm);
 			}

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -123,8 +123,7 @@ class Realm {
 	
 	public function findDeadInferiors() {
 		$all = new ArrayCollection;
-		$this->getInferiors() as $subrealms
-		foreach ($subrealms = $subrealm) {
+		foreach ($this->getInferiors() as $subrealms) {
 			if ($subrealm->getActive = false) {
 			$all->add($subrealm);
 			}

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -120,6 +120,18 @@ class Realm {
 
 		return $all;
 	}
+	
+	public function findDeadInferiors() {
+		$all = new ArrayCollection;
+		$this->findAllInferiors() as $subrealms
+		foreach ($subrealms = $subrealm) {
+			if ($subrealm->getActive = false) {
+			$all->add($subrealm);
+			}
+		}
+	
+		return $all;
+	}
 
 	public function findAllSuperiors($include_myself = false) {
 		$all = new ArrayCollection;

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -124,7 +124,7 @@ class Realm {
 	public function findDeadInferiors() {
 		$all = new ArrayCollection;
 		foreach ($this->getInferiors() as $subrealms) {
-			if ($subrealm->getActive() = false) {
+			if (!$subrealm->getActive()) {
 			$all->add($subrealm);
 			}
 		}

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -124,7 +124,7 @@ class Realm {
 	public function findDeadInferiors() {
 		$all = new ArrayCollection;
 		foreach ($this->getInferiors() as $subrealms) {
-			if ($subrealm->getActive = false) {
+			if ($subrealm->getActive() = false) {
 			$all->add($subrealm);
 			}
 		}

--- a/src/BM2/SiteBundle/Entity/Realm.php
+++ b/src/BM2/SiteBundle/Entity/Realm.php
@@ -123,7 +123,7 @@ class Realm {
 	
 	public function findDeadInferiors() {
 		$all = new ArrayCollection;
-		$this->findAllInferiors() as $subrealms
+		$this->getInferiors() as $subrealms
 		foreach ($subrealms = $subrealm) {
 			if ($subrealm->getActive = false) {
 			$all->add($subrealm);

--- a/src/BM2/SiteBundle/Form/RealmRestoreType.php
+++ b/src/BM2/SiteBundle/Form/RealmRestoreType.php
@@ -23,7 +23,10 @@ class RealmRestoreType extends AbstractType {
         ));
     }
 
-    //FIXME: Find out what the random numbers are above and what they mean!
+    /* 
+    FIXME: Find out what the random numbers after "realmrestore_" are (above) and what they mean!
+    Since I've not gotten a response after about a week of waiting, I guess I'll just submit this and be told what breaks. -- Andrew 
+    */
 
     public function buildForm(FormBuilderInterface $builder, array $options) {
         $realm = $this->realm;

--- a/src/BM2/SiteBundle/Form/RealmRestoreType.php
+++ b/src/BM2/SiteBundle/Form/RealmRestoreType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BM2\SiteBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+
+class RealmRestoreType extends AbstractType {
+
+    private $realm;
+
+    public function __construct($realm) {
+        $this->realm = $realm;
+    }
+
+    public function configureOptions(OptionsResolver $resolver) {
+        $resolver->setDefaults(array(
+            'intention'       => 'realmrestore_13535',
+            'translation_domain' => 'politics',
+            'data_class'		=> 'BM2\SiteBundle\Entity\Realm',
+        ));
+    }
+
+    //FIXME: Find out what the random numbers are above and what they mean!
+
+    public function buildForm(FormBuilderInterface $builder, array $options) {
+        $realm = $this->realm;
+
+        $builder->add('type', 'entity', array(
+            'required'=>true,
+            'placeholder'=>'diplomacy.restore.empty',
+            'label'=>'realm.deadrealm',
+            'class'=>'BM2SiteBundle:Realm',
+            'choice_label'=>'name'
+            'query_builder'=>function(EntityRepository $er) use ($realm) {
+                $qb = $er->createQueryBuilder('r');
+                $qb->where('e.realm = :realm')->setParameters(array('superior' => $realm, 'active' => false);
+                $qb->orderBy('r.name', 'ASC');
+                return $qb;
+            }
+        ));
+
+        $builder->add('submit', 'submit', array('label'=>'realm.restore.submit'));
+
+    }
+
+    public function getName() {
+        return 'realmrestore';
+    }
+}

--- a/src/BM2/SiteBundle/Resources/translations/actions.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/actions.en.yml
@@ -127,7 +127,9 @@ location:
  exit:
   name:         Exit the Settlement
   description:  Peacefully exit this settlement.
-  result:       You have passed the gates and are now outside %settlement%.  
+  result:
+   left:        You have passed the gates and are now outside %settlement%.
+   denied:      You cannot presently leave this settlement.
  quests:
   name:         Local Quests
   description:  Check out current and past quests from this region.

--- a/src/BM2/SiteBundle/Resources/translations/actions.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/actions.en.yml
@@ -124,6 +124,10 @@ location:
   result:
    entered:     You have passed the gates and are now inside %settlement%.
    denied:      Guards at the gates of %settlement% deny you entry. You can force your way in by attacking the settlement, of course.
+ exit:
+  name:         Exit the Settlement
+  description:  Peacefully exit this settlement.
+  result:       You have passed the gates and are now outside %settlement%.  
  quests:
   name:         Local Quests
   description:  Check out current and past quests from this region.

--- a/src/BM2/SiteBundle/Resources/translations/communication.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/communication.en.yml
@@ -215,6 +215,7 @@ event:
   abdicated:    %character-1% has abdicated and handed control of the realm to %character-2%.
   abdicated2:   %character% has abdicated without a successor.
   deserted:     Vanished into history with no members remaining.
+  restored:     %character% of %realm%, has revived the realm, becoming it's new ruler.
   war:
    declared:    Declared war "%war%".
    received:    %realm% has declared war, announcing settlements of your realm as targets. They call it "%war%".

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -1402,6 +1402,7 @@ unavailable:
  nosettlement:  You are not near any settlement.
  notinside:     You are not inside the settlement.
  inside:        You are inside the settlement.
+ outside:       You are not currently inside a settlement.
  noregion:      You are not in an inhabited area.
  nodock:        There are no docks nearby.
  noship:        You do not have a ship nearby.

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -1400,7 +1400,7 @@ unavailable:
  regrouping:    Your troops are regrouping, you cannot attack until they are ready again.
  atsea:         You are travelling at sea.
  nosettlement:  You are not near any settlement.
- notinside:     You are not inside the settlement.
+ notinside:     You are not inside a settlement.
  inside:        You are inside the settlement.
  outside:       You are not currently inside a settlement.
  noregion:      You are not in an inhabited area.

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -980,7 +980,7 @@ soldier:
  medium infantry:  medium infantry|medium infantry
  heavy infantry:   heavy infantry|heavy infantry
  archer:           archer|archers
- armoured archer:  armored archer|armored archer
+ armoured archer:  armored archer|armored archers
  mounted archer:   mounted archer|mounted archers
  cavalry:          cavalry|cavalry
  light cavalry:    light cavalry|light cavalry

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -25,6 +25,7 @@ menu:
  credits:   credits
  contact:   contact
  forum:     forum
+ wiki:      wiki
  bugs:      bugtracker
  about:     about
  manual:    manual

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -1434,6 +1434,8 @@ unavailable:
  novassals:     You do not have any vassals (your own characters don't count).
  fewestates:    A new realm needs to have at least two estates.
  notvassal:     You are not a vassal.
+ tooalive:      Your realm has no subrealms that have been abandoned.
+ nosubrealms:   Your realm has no subrealms.
  toolow:        Your realm is of the lowest designation and thus cannot have subrealms.
  toosmall:      Your realm needs to have at least two estates to split one (or more) off into a subrealm.
  attacking:     you are busy attacking the nearby settlement.

--- a/src/BM2/SiteBundle/Resources/translations/messages.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/messages.en.yml
@@ -1035,6 +1035,10 @@ events:
   medium:   only interesting
   high:     only important
   ultra:    only very important
+ soldierlog: 
+  title:     Soldier Log for link-soldier-name
+ entry:      Log Entries
+ time:       Date
 
 interaction:
  message:

--- a/src/BM2/SiteBundle/Resources/translations/politics.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/politics.en.yml
@@ -408,7 +408,8 @@ diplomacy:
   description:  Use your position as ruler of a realm to restore one if its abandoned subrealms.
   intro: >
     As the ruler of %name%, you can use your authority to bring back into existence any of it's abandoned subrealms.
-    All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler.
+    All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler, allowing you to then give that position to another..
+  restore:      -- chose --
   submit:       revive realm
   invalid:
    realm:       in order to revive a realm, you must select the realm to revive.

--- a/src/BM2/SiteBundle/Resources/translations/politics.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/politics.en.yml
@@ -408,7 +408,7 @@ diplomacy:
   description:  Use your position as ruler of a realm to restore one if its abandoned subrealms.
   intro: >
     As the ruler of %name%, you can use your authority to bring back into existence any of it's abandoned subrealms.
-    All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler, allowing you to then give that position to another..
+    All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler, allowing you to then give that position to another.
   restore:      -- chose --
   submit:       revive realm
   invalid:

--- a/src/BM2/SiteBundle/Resources/translations/politics.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/politics.en.yml
@@ -403,7 +403,7 @@ diplomacy:
    current:     Is your current superior realm.
   done:         You have successfully submitted to the superior power of %target% and made your %realm% a part of it.
 
- revive:
+ restore:
   name:         Revive Subrealm
   description:  Use your position as ruler of a realm to restore one if its abandoned subrealms.
   intro: >
@@ -412,6 +412,7 @@ diplomacy:
   submit:       revive realm
   invalid:
    realm:       in order to revive a realm, you must select the realm to revive.
+  success:      You have successfully restored the subrealm.
 
  subrealm:
   name:         Create Subrealm

--- a/src/BM2/SiteBundle/Resources/translations/politics.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/politics.en.yml
@@ -404,15 +404,15 @@ diplomacy:
   done:         You have successfully submitted to the superior power of %target% and made your %realm% a part of it.
 
  restore:
-  name:         Revive Subrealm
+  name:         Restore Subrealm
   description:  Use your position as ruler of a realm to restore one if its abandoned subrealms.
   intro: >
     As the ruler of %name%, you can use your authority to bring back into existence any of it's abandoned subrealms.
     All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler, allowing you to then give that position to another.
-  restore:      -- chose --
+  restore:      -- choose --
   submit:       revive realm
   invalid:
-   realm:       in order to revive a realm, you must select the realm to revive.
+   realm:       in order to restore a realm, you must select the realm to revive.
   success:      You have successfully restored the subrealm.
 
  subrealm:

--- a/src/BM2/SiteBundle/Resources/translations/politics.en.yml
+++ b/src/BM2/SiteBundle/Resources/translations/politics.en.yml
@@ -403,6 +403,16 @@ diplomacy:
    current:     Is your current superior realm.
   done:         You have successfully submitted to the superior power of %target% and made your %realm% a part of it.
 
+ revive:
+  name:         Revive Subrealm
+  description:  Use your position as ruler of a realm to restore one if its abandoned subrealms.
+  intro: >
+    As the ruler of %name%, you can use your authority to bring back into existence any of it's abandoned subrealms.
+    All you need to do is determine which subrealm you wish to restore, and you will be made it's new ruler.
+  submit:       revive realm
+  invalid:
+   realm:       in order to revive a realm, you must select the realm to revive.
+
  subrealm:
   name:         Create Subrealm
   description:  Turn parts of your realm into a smaller sub-realm.

--- a/src/BM2/SiteBundle/Resources/views/Character/rename.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Character/rename.html.twig
@@ -12,7 +12,7 @@
 		</p>
 	{% else %}
 	<p>{{ "meta.rename.intro"|trans({},"actions")|raw }}</p>
-	<form class="wide" action="{{ path('bm2_site_character_rename') }}" method="post" {{ form_enctype(form) }}>
+	<form class="wide" action="{{ path('bm2_site_character_rename') }}" method="post" {{ form_start(form) }}>
 		{{ form_widget(form) }}
 		<button type="submit" name="submit">{{ "meta.rename.submit"|trans({},"actions") }}</button>
 	</form>

--- a/src/BM2/SiteBundle/Resources/views/Character/summary.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Character/summary.html.twig
@@ -45,7 +45,7 @@
 
 <h3>{{ 'summary.events'|trans|title }}</h3>
 {% set has_events = false %}
-<table class="eventlog">
+<table id="eventlog" class="eventlog">
 	<thead></thead>
 	<tbody>
 	{% for event in events %}
@@ -249,25 +249,29 @@
 {% endblock %}
 
 {% block jquery %}
-$("#fullread").click(function(){
-	$.post("{{ path('bm2_site_events_fullread', {"which":"me"}) }}", function() {
-		$("#fullread").replaceWith('<div class="success">{{ "events.alldone2"|trans }}</div>');
-	});
-});
-$("#fullread2").click(function(){
-	$.post("{{ path('bm2_site_events_fullread', {"which":"all"}) }}", function() {
-		$("#fullread_wrapper").replaceWith('<div class="success">{{ "events.alldone"|trans }}</div>');
-	});
-});
-
-$("#expandscouting").click(function(){
-	$("#expandscouting").parent().after('<img src="{{ asset('bundles/bm2site/images/loader.png') }}"/>');
-	$("#expandscouting").remove();
-	$.get("{{ path('bm2_scouting') }}", function(data) {
-		$("#nearbyothers").replaceWith(data);
-		$("#scouting").tablesorter({
-			sortList: [[0,0]],
+	$("#fullread").click(function(){
+		$.post("{{ path('bm2_site_events_fullread', {"which":"me"}) }}", function() {
+			$("#fullread").replaceWith('<div class="success">{{ "events.alldone2"|trans }}</div>');
 		});
 	});
-});
+	$("#fullread2").click(function(){
+		$.post("{{ path('bm2_site_events_fullread', {"which":"all"}) }}", function() {
+			$("#fullread_wrapper").replaceWith('<div class="success">{{ "events.alldone"|trans }}</div>');
+		});
+	});
+
+	$("#expandscouting").click(function(){
+		$("#expandscouting").parent().after('<img src="{{ asset('bundles/bm2site/images/loader.png') }}"/>');
+		$("#expandscouting").remove();
+		$.get("{{ path('bm2_scouting') }}", function(data) {
+			$("#nearbyothers").replaceWith(data);
+			$("#scouting").tablesorter({
+				sortList: [[0,0]],
+			});
+		});
+	});
+
+	$("#eventlog").tablesorter({
+		sortList: [[1,0,0], [0,0,0]],
+	});
 {% endblock %}

--- a/src/BM2/SiteBundle/Resources/views/Construction/roads.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Construction/roads.html.twig
@@ -19,7 +19,7 @@
 	<div id="over20" class="warning hidden">{{ 'economy.build.warning.over20percent'|trans({}, "actions") }}</div>
 	<div id="over50" class="warning hidden">{{ 'economy.build.warning.over50percent'|trans({}, "actions") }}</div>
 	<div id="over100" class="error hidden">{{ 'economy.build.unavailable.over100percent'|trans({}, "actions") }}</div>
-	<form class="wide" action="{{ path('bm2_site_construction_roads') }}" method="post" {{ form_enctype(form) }}>
+	<form class="wide" action="{{ path('bm2_site_construction_roads') }}" method="post" {{ form_start(form) }}>
 	{{ form_widget(form._token) }}
 	{% if roadsdata is not empty %}
 	<table>

--- a/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
@@ -39,7 +39,7 @@
 		{% endif %}
 	{% endif %}
 	{% if form %}
-		<form class="wide" action="{{ path('bm2_eventlog', {'id':log.id}) }}" method="post" {{ form_enctype(form) }}>
+		<form class="wide" action="{{ path('bm2_eventlog', {'id':log.id}) }}" method="post" {{ form_start(form) }}>
 			{{ form_widget(form) }}
 			<button name="submit">{{ 'entourage.assign.submit'|trans({},"actions") }}</button>
 		</form>

--- a/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
@@ -23,8 +23,8 @@
 	{% elseif gap == false %}
 		{% set gap = true %}
 		<tr>
-			<td>...</td>
-			<td>...</td>
+			<td>0-0-0</td>
+			<td>{{ 'events.research.intro'|trans }}</td>
 		</tr>
 	{% endif %}
 {% endfor %}

--- a/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/eventdata.html.twig
@@ -1,4 +1,3 @@
-<dl class="eventlog">
 {% set gap = false %}
 {% set shown = 0 %}
 {% for event in log.events %}
@@ -16,16 +15,19 @@
 	{% if visible %}
 		{% set shown = shown + 1 %}
 		{% set gap = false %}
-{# TODO: being able to use the History:: consts here would be really cool #}
-		<dt class="prio_{{ event.priority }}">{{ event.cycle|gametime('short') }}</dt>
-		<dd class="prio_{{ event.priority }}">{{ event|eventtranslate }}</dd>
+		{# TODO: being able to use the History:: consts here would be really cool #}
+		<tr class="prio_{{ event.priority }}">
+			<td>{{ event.cycle|gametime('short') }}</td>
+			<td>{{ event|eventtranslate }}</td>
+		</tr>
 	{% elseif gap == false %}
 		{% set gap = true %}
-		<dt>...</dt>
-		<dd>...</dd>
+		<tr>
+			<td>...</td>
+			<td>...</td>
+		</tr>
 	{% endif %}
 {% endfor %}
-</dl>
 
 {% if log.events|length > shown %}
 	{% if research is defined and research.assignedEntourage is defined %}

--- a/src/BM2/SiteBundle/Resources/views/Events/eventlog.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/eventlog.html.twig
@@ -1,5 +1,10 @@
 {% extends "BM2SiteBundle::layout.html.twig" %}
 
+{% block includes %}
+	{{ parent() }}
+	<script src="{{ asset('bundles/bm2site/tablesorter/jquery.tablesorter.min.js') }}"></script>
+{% endblock %}
+
 {% block content %}
 <h2>{{ 'events.logtitle'|trans({'%subject%':link(log.subject)})|title|raw }}</h2>
 {% if log.realm or log.settlement %}
@@ -15,16 +20,24 @@
 	<input type="radio" id="filter_high" name="radio" /><label for="filter_high">{{ 'events.filter.high'|trans }}</label>
 	<input type="radio" id="filter_ultra" name="radio" /><label for="filter_ultra">{{ 'events.filter.ultra'|trans }}</label>
 </div>
-
+<table id="eventlog" cellpadding="0" cellspacing="0"><thead>
+	<tr>
+		<th>{{ 'events.time'|trans }}</th>
+		<th>{{ 'events.entry'|trans }}</th>
+	</tr>
+</thead>
+<tbody>
 {% include "BM2SiteBundle:Events:eventdata.html.twig" with { "log":log, "metas":metas, "research":true} %}
-
+</tbody></table>
 {% endblock %}
 
 {% block javascript %}
 $("#select_type").buttonset();
 
 $("#filter_all").change(function(){
-	$(".eventlog").children().show();
+	$(".prio_0").show();
+	$(".prio_10").show();
+	$(".prio_20").show();
 });
 $("#filter_medium").change(function(){
 	$(".prio_0").hide();
@@ -41,6 +54,12 @@ $("#filter_ultra").change(function(){
 	$(".prio_10").hide();
 	$(".prio_20").hide();
 });
+
+{% block jquery %}
+	$("#eventlog").tablesorter({
+		sortList: [[0,1],[1,0]],
+	});
+{% endblock %}
 
 $("#allread").click(function(){
 	$.post("{{ path('bm2_site_events_allread', {"log":log.id}) }}", function() {

--- a/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
@@ -15,6 +15,7 @@
 	</tr>
 </thead><tbody>
 {% for event in soldier.events %}
+	<tr>
 		<td>{{ event.cycle|gametime('short') }}</td>
 		<td>{{ event|logtranslate }}</td>
 	</tr>

--- a/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
@@ -11,7 +11,7 @@
 <table id="soldierlog"><thead>
 	<tr>
 		<th>{{ 'events.time'|trans }}</th>
-		<th>{{ 'events.soldierlog.entry'|trans }}</th>
+		<th>{{ 'events.entry'|trans }}</th>
 	</tr>
 </thead><tbody>
 {% for event in soldier.events %}

--- a/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Events/soldierlog.html.twig
@@ -1,13 +1,30 @@
 {% extends "BM2SiteBundle::layout.html.twig" %}
 
+{% block includes %}
+	{{ parent() }}
+	<script src="{{ asset('bundles/bm2site/tablesorter/jquery.tablesorter.min.js') }}"></script>
+{% endblock %}
+
 {% block content %}
-<h2>soldier log of {{ soldier.name }}</h2>
+<h2>{{ 'events.soldierlog.title'|trans({'link-soldier-name':soldier.name}, "messages")|title|raw }}</h2>
 
-<dl class="eventlog">
+<table id="soldierlog"><thead>
+	<tr>
+		<th>{{ 'events.time'|trans }}</th>
+		<th>{{ 'events.soldierlog.entry'|trans }}</th>
+	</tr>
+</thead><tbody>
 {% for event in soldier.events %}
-	<dt>{{ event.cycle|gametime('short') }}</dt>
-	<dd>{{ event|logtranslate }}</dd>
+		<td>{{ event.cycle|gametime('short') }}</td>
+		<td>{{ event|logtranslate }}</td>
+	</tr>
 {% endfor %}
-</dl>
+</tbody></table>
 
+{% endblock %}
+
+{% block jquery %}
+	$("#soldierlog").tablesorter({
+		sortList: [[0,1],[1,0]],
+	});
 {% endblock %}

--- a/src/BM2/SiteBundle/Resources/views/Heraldry/create.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Heraldry/create.html.twig
@@ -81,7 +81,7 @@
 
 {{ form_errors(form) }}
 
-<form class="wide" action="{{ path('bm2_site_heraldry_create') }}" method="post" {{ form_enctype(form) }}>
+<form class="wide" action="{{ path('bm2_site_heraldry_create') }}" method="post" {{ form_start(form) }}>
 	{{ form_widget(form) }}
 
 	<div id="thebuttons">

--- a/src/BM2/SiteBundle/Resources/views/Payment/subscription.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Payment/subscription.html.twig
@@ -21,7 +21,7 @@
 {% endfor %}
 </div>
 
-<form action="{{ path('bm2_site_payment_subscription') }}" method="post" {{ form_enctype(form) }}>
+<form action="{{ path('bm2_site_payment_subscription') }}" method="post" {{ form_start(form) }}>
 	<span class="hidden">{{ form_widget(form) }}</span>
 	<button>{{ 'account.sub.submit'|trans }}</button>
 </form>

--- a/src/BM2/SiteBundle/Resources/views/Politics/list.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Politics/list.html.twig
@@ -37,7 +37,7 @@
 	{{ macros.member_row(form.members.vars.prototype) }}
 </tr>
 </table>
-<form class="wide" action="{{ path('bm2_site_politics_list', {'id':listing.id?listing.id:0}) }}" method="post" {{ form_enctype(form) }}>
+<form class="wide" action="{{ path('bm2_site_politics_list', {'id':listing.id?listing.id:0}) }}" method="post" {{ form_start(form) }}>
 	{{ form_widget(form._token) }}
 	{{ form_row(form.name) }}
 	{{ form_row(form.public) }}

--- a/src/BM2/SiteBundle/Resources/views/Politics/oath.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Politics/oath.html.twig
@@ -26,7 +26,7 @@
 	{% if nobody is defined %}
 		{{ "oath.nobody"|trans({},"politics") }}
 	{% else %}
-		<form class="wide" action="{{ path('bm2_site_politics_oath') }}" method="post" {{ form_enctype(form) }}>
+		<form class="wide" action="{{ path('bm2_site_politics_oath') }}" method="post" {{ form_start(form) }}>
 			{{ form_widget(form) }}		
 			<button type="submit">{{ "oath.submit"|trans({},"politics") }}</button>
 		</form>

--- a/src/BM2/SiteBundle/Resources/views/Politics/prisoners.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Politics/prisoners.html.twig
@@ -17,7 +17,7 @@
 {% endfor %}
 
 {{ form_errors(form) }}
-<form action="" method="post" {{ form_enctype(form) }}>
+<form action="" method="post" {{ form_start(form) }}>
 {{ form_widget(form._token) }}
 
 <table>

--- a/src/BM2/SiteBundle/Resources/views/Realm/manage.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Realm/manage.html.twig
@@ -11,7 +11,7 @@
 <h2>{{ 'realm.manage.name'|trans({"%name%":realm.name},"politics")|title }}</h2>
 <p>{{ 'realm.manage.intro'|trans({"%name%":realm.name},"politics")|raw }}</p>
 
-<form id="realmdata" class="wide" action="{{ path('bm2_site_realm_manage', {'realm':realm.id}) }}" method="post" {{ form_enctype(form) }}>
+<form id="realmdata" class="wide" action="{{ path('bm2_site_realm_manage', {'realm':realm.id}) }}" method="post" {{ form_start(form) }}>
 	{{ form_widget(form) }}
 </form>
 

--- a/src/BM2/SiteBundle/Resources/views/Realm/restore.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Realm/restore.html.twig
@@ -1,14 +1,14 @@
 {% extends "BM2SiteBundle::layout.html.twig" %}
 
 {% block content %}
-<h2>{{ 'diplomacy.revive.name'|trans({},"politics")|title }}</h2>
+<h2>{{ 'diplomacy.restore.name'|trans({},"politics")|title }}</h2>
 <div style="float:right;margin-top:-4em">
 	&nbsp;<ul id="loadlist" class="shortlist" style="display:inline"></ul>
 	<div id="map" style="min-width:30em;min-height:30em;margin-left:2em"></div>
 </div>
 <div id="sd_anchor" style="margin-right:1em;height:30em;float:right"></div>
 <div id="sd" class="hidden" title="dummy"></div>
-<p>{{ 'diplomacy.revive.intro'|trans({"%name%":realm.name},"politics")|raw }}</p>
+<p>{{ 'diplomacy.restore.intro'|trans({"%name%":realm.name},"politics")|raw }}</p>
 
 {{ form(form) }}
 

--- a/src/BM2/SiteBundle/Resources/views/Realm/revive.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Realm/revive.html.twig
@@ -1,0 +1,15 @@
+{% extends "BM2SiteBundle::layout.html.twig" %}
+
+{% block content %}
+<h2>{{ 'diplomacy.revive.name'|trans({},"politics")|title }}</h2>
+<div style="float:right;margin-top:-4em">
+	&nbsp;<ul id="loadlist" class="shortlist" style="display:inline"></ul>
+	<div id="map" style="min-width:30em;min-height:30em;margin-left:2em"></div>
+</div>
+<div id="sd_anchor" style="margin-right:1em;height:30em;float:right"></div>
+<div id="sd" class="hidden" title="dummy"></div>
+<p>{{ 'diplomacy.revive.intro'|trans({"%name%":realm.name},"politics")|raw }}</p>
+
+{{ form(form) }}
+
+{% endblock %}

--- a/src/BM2/SiteBundle/Resources/views/Realm/view.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Realm/view.html.twig
@@ -129,7 +129,11 @@
 			-
 		{% endif %}
 	</td>
-	<td><a href="{{ path('bm2_site_realm_viewrelations', {'realm':realm.id, 'target':relation.target.id}) }}">{{ 'diplomacy.report.link'|trans({},"politics") }}</a></td>
+	<td>
+		{% if character %}
+			<a href="{{ path('bm2_site_realm_viewrelations', {'realm':realm.id, 'target':relation.target.id}) }}">{{ 'diplomacy.report.link'|trans({},"politics") }}</a>
+		{% endif %}
+	</td>
 </tr>
 {% endfor %}
 </tbody>

--- a/src/BM2/SiteBundle/Resources/views/Settlement/permissions.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Settlement/permissions.html.twig
@@ -26,7 +26,7 @@
 		{{ macros.permission_row(form.permissions.vars.prototype) }}
 	</tr>
 	</table>
-	<form class="wide" action="{{ path('bm2_site_settlement_permissions', {'id':settlement.id}) }}" method="post" {{ form_enctype(form) }}>
+	<form class="wide" action="{{ path('bm2_site_settlement_permissions', {'id':settlement.id}) }}" method="post" {{ form_start(form) }}>
 		{{ form_errors(form) }}
 		{{ form_widget(form._token) }}
 		<h3>{{ "control.permissions.general"|trans({},"actions")|title }}</h3>

--- a/src/BM2/SiteBundle/Resources/views/Settlement/settlement.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Settlement/settlement.html.twig
@@ -16,7 +16,7 @@
 	<div id="sd" class="hidden" title="dummy"></div>
 	<h2>{{ settlement.name }}</h2>
 	{% if details.startme is defined %}
-		<form id="form_map" action="{{ path('bm2_site_character_start') }}" method="post" {{ form_enctype(details.startme) }}>
+		<form id="form_map" action="{{ path('bm2_site_character_start') }}" method="post" {{ form_start(details.startme) }}>
 			{{ form_widget(details.startme) }}
 			<button>{{ 'character.start.submit'|trans|title }}</button>
 		</form>

--- a/src/BM2/SiteBundle/Resources/views/Settlement/settlement.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Settlement/settlement.html.twig
@@ -62,7 +62,7 @@
 		{% if familiarity %}<li><small>{{ ('familiarity.'~familiarity)|trans }}</small></li>{% endif %}
 		<li>{{ area|area }}</li>
 		<li>{{ density|number_format }} {{ 'popdensity'|trans }}</li>
-		{% if true or details.spot or isowner %}
+		{% if details.spot or isowner %}
 			<li class="tt_botleft" title="{{ ('settlement.security.tt')|trans }}">{{ ('settlement.security.'~security)|trans }}</li>
 		{% endif %}
 		{% if isowner %}

--- a/src/BM2/SiteBundle/Resources/views/element/nav_guest.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/element/nav_guest.html.twig
@@ -5,6 +5,7 @@
 	<li><a href="{{ path('bm2_fiction') }}">{{ 'menu.fiction'|trans }}</a></li>
 	<li><a href="{{ path('bm2_vips') }}">{{ 'menu.vips'|trans }}</a></li>
 	<li><a href="http://forum.mightandfealty.com">{{ 'menu.community'|trans }}</a></li>
+	<li><a href="http://wiki.mightandfealtyfans.org">{{ 'menu.wiki'|trans }}</a></li>
 	{% if not simple or biglogo is defined %}
 		{% if app.user and is_granted("IS_AUTHENTICATED_REMEMBERED") %}
 			<li><a href="{{ path('fos_user_profile_show') }}">{{ 'menu.profile'|trans }}</a></li>

--- a/src/BM2/SiteBundle/Resources/views/element/nav_guest.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/element/nav_guest.html.twig
@@ -5,7 +5,7 @@
 	<li><a href="{{ path('bm2_fiction') }}">{{ 'menu.fiction'|trans }}</a></li>
 	<li><a href="{{ path('bm2_vips') }}">{{ 'menu.vips'|trans }}</a></li>
 	<li><a href="http://forum.mightandfealty.com">{{ 'menu.community'|trans }}</a></li>
-	<li><a href="http://wiki.mightandfealtyfans.org">{{ 'menu.wiki'|trans }}</a></li>
+	<li><a href="http://wiki.maffans.org">{{ 'menu.wiki'|trans }}</a></li>
 	{% if not simple or biglogo is defined %}
 		{% if app.user and is_granted("IS_AUTHENTICATED_REMEMBERED") %}
 			<li><a href="{{ path('fos_user_profile_show') }}">{{ 'menu.profile'|trans }}</a></li>

--- a/src/BM2/SiteBundle/Resources/views/element/nav_main.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/element/nav_main.html.twig
@@ -96,6 +96,11 @@
 					</ul>
 				</li>
 				{% endif %}
+				{% set check = dispatcher.locationLeaveTest() %}
+				{% if check.url is defined %}
+					<h3>{{ 'location.title'|trans({},"actions") }}</h3>
+					<a href="{{ path(check.url) }}">{{ check.name|trans({},"actions") }}</a>
+				{% endif %}
 				{% if character.insidesettlement and character.insidesettlement.owner == character %}
 				<li class="part">
 					<h3>{{ 'menu.economy'|trans|title }}</h3>

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -1432,7 +1432,7 @@ class Dispatcher {
 		if ($this->realm->getInferiors()->count() > 0) {
 			return array("name"=>"diplomacy.restore", "description"=>"unavailable.nosubrealms");
 		}
-		if ($this->realm->findDeadInferiors()->count() = 0) {
+		if ($this->realm->findDeadInferiors()->count() == 0) {
 			return array("name"=>"diplomacy.restore", "description"=>"unavailable.tooalive");
 		}
 		if (!$this->realm->findRulers()->contains($this->getCharacter())) {

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -116,6 +116,12 @@ class Dispatcher {
 			$actions[] = array("name"=>"location.enter.name", "description"=>"unavailable.nosettlement");
 		}
 
+		if ($this->getLeaveableSettlementTest()) {
+			$actions[] = $this->locationLeaveTest(true);
+		} else {
+			$actions[] = array("name"=>"location.leave.name", "description"=>"unavaiable.nosettlement");
+		}
+
 		$actions[] = $this->locationQuestsTest();
 		$actions[] = $this->locationEmbarkTest();
 
@@ -500,6 +506,30 @@ class Dispatcher {
 			return $this->action("location.enter", "bm2_site_actions_enter");
 		}
 
+	}
+	
+	public function locationLeaveTest($check_duplicate=false) {
+		if (($check = $this->interActionsGenericTests() !== true) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.$check");
+		}
+		if (!$this->getCharacter()->getInsideSettlement()) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.outside");
+		}
+		if (!$place = $this->getActionableSettlement()) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.nosettlement");
+		}
+		if ($check_duplicate && $this->getCharacter()->isDoingAction('settlement.exit')) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.already");
+		}
+		if ($this->getCharacter()->isInBattle()) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.inbattle");
+		}
+		if ($this->getCharacter()->isPrisoner()) {
+			return array("name"=>"location.exit.name", "description"=>"unavailable.prisoner");
+			}
+		} else {
+			return $this->action("location.exit", "bm2_site_actions_exit");
+		}
 	}
 
 	public function locationQuestsTest() {
@@ -1517,6 +1547,12 @@ class Dispatcher {
 			}
 		}
 		return $this->actionableSettlement;
+	}
+
+	public function getLeaveableSettlement() {
+		if ($this->getCharacter()->getInsideSettlement()) {
+			return $this->getCharacter()->getInsideSettlement();
+		}
 	}
 
 	public function getActionableRegion() {

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -1429,7 +1429,7 @@ class Dispatcher {
 		if (($check = $this->politicsActionsGenericTests()) !== true) {
 			return array("name"=>"diplomacy.restore", "description"=>"unavailable.$check");
 		}
-		if ($this->realm->findInferiors()->count() > 0) {
+		if ($this->realm->getInferiors()->count() > 0) {
 			return array("name"=>"diplomacy.restore", "description"=>"unavailable.nosubrealms");
 		}
 		if ($this->realm->findDeadInferiors()->count() = 0) {

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -1425,6 +1425,21 @@ class Dispatcher {
 		return $this->action("diplomacy.subrealm", "bm2_site_realm_subrealm", true, array('realm'=>$this->realm->getId()));
 	}
 
+	public function diplomacyRestoreTest() {
+		if (($check = $this->politicsActionsGenericTests()) !== true) {
+			return array("name"=>"diplomacy.restore", "description"=>"unavailable.$check");
+		}
+		if ($this->realm->findInferiors()->count() > 0) {
+			return array("name"=>"diplomacy.restore", "description"=>"unavailable.nosubrealms");
+		}
+		if ($this->realm->findDeadInferiors()->count() = 0) {
+			return array("name"=>"diplomacy.restore", "description"=>"unavailable.tooalive");
+		}
+		if (!$this->realm->findRulers()->contains($this->getCharacter())) {
+			return array("name"=>"diplomacy.restore", "description"=>"unavailable.notleader");
+		}
+		return $this->action("diplomacy.restore", "bm2_site_realm_restore", true, array('realm'=>$this->realm->getId()))
+	}
 
 	public function diplomacyBreakHierarchyTest() {
 		if (($check = $this->politicsActionsGenericTests()) !== true) {

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -119,7 +119,7 @@ class Dispatcher {
 		if ($this->getLeaveableSettlementTest()) {
 			$actions[] = $this->locationLeaveTest(true);
 		} else {
-			$actions[] = array("name"=>"location.leave.name", "description"=>"unavaiable.nosettlement");
+			$actions[] = array("name"=>"location.exit.name", "description"=>"unavailable.inside");
 		}
 
 		$actions[] = $this->locationQuestsTest();

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -425,6 +425,7 @@ class Dispatcher {
 		$actions[] = $this->diplomacyHierarchyTest();
 		$actions[] = $this->diplomacySubrealmTest();
 		$actions[] = $this->diplomacyBreakHierarchyTest();
+		$actions[] = $this->diplomacyRestoreTest();
 
 		return array("name"=>"diplomacy", "elements"=>$actions);
 	}

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -1438,7 +1438,7 @@ class Dispatcher {
 		if (!$this->realm->findRulers()->contains($this->getCharacter())) {
 			return array("name"=>"diplomacy.restore", "description"=>"unavailable.notleader");
 		}
-		return $this->action("diplomacy.restore", "bm2_site_realm_restore", true, array('realm'=>$this->realm->getId()))
+		return $this->action("diplomacy.restore", "bm2_site_realm_restore", true, array('realm'=>$this->realm->getId()));
 	}
 
 	public function diplomacyBreakHierarchyTest() {

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -509,7 +509,7 @@ class Dispatcher {
 	}
 	
 	public function locationLeaveTest($check_duplicate=false) {
-		if (($check = $this->interActionsGenericTests() !== true) {
+		if (($check = $this->interActionsGenericTests()) !== true) {
 			return array("name"=>"location.exit.name", "description"=>"unavailable.$check");
 		}
 		if (!$this->getCharacter()->getInsideSettlement()) {
@@ -526,7 +526,6 @@ class Dispatcher {
 		}
 		if ($this->getCharacter()->isPrisoner()) {
 			return array("name"=>"location.exit.name", "description"=>"unavailable.prisoner");
-			}
 		} else {
 			return $this->action("location.exit", "bm2_site_actions_exit");
 		}

--- a/src/BM2/SiteBundle/Service/RealmManager.php
+++ b/src/BM2/SiteBundle/Service/RealmManager.php
@@ -211,7 +211,7 @@ class RealmManager {
 		$this->removeRulerLiege($realm, $newruler);
 	}
 	
-	public function restoreRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
+	public function restoreSubRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
 		//this will allow superior realms to restore dead sub-realms --Andrew
 		if ($deadrealm->getActive() == false && $deadrealm->getSuperior()==$realm) {
 			$this->makeRuler($deadrealm, $newruler);

--- a/src/BM2/SiteBundle/Service/RealmManager.php
+++ b/src/BM2/SiteBundle/Service/RealmManager.php
@@ -219,7 +219,7 @@ class RealmManager {
 			$this->history->logEvent(
 				$deadrealm,
 				'event.realm.restored',
-				array('%link-realm%'=>$realm->getID(), '%link-realm%'=>$deadrealm->getId(), '%link-character%'=>$newruler->getId()),
+				array('%link-realm%'=>$realm->getID(), '%link-character%'=>$newruler->getId()),
 				History::ULTRA, true
 			);
 		}

--- a/src/BM2/SiteBundle/Service/RealmManager.php
+++ b/src/BM2/SiteBundle/Service/RealmManager.php
@@ -210,6 +210,20 @@ class RealmManager {
 
 		$this->removeRulerLiege($realm, $newruler);
 	}
+	
+	public function restoreRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
+		//this will allow superior realms to restore dead sub-realms --Andrew
+		if ($deadrealm->getActive() == false && $deadrealm->getSuperior()==$realm) {
+			$this->makeRuler($realm=$deadrealm, $newruler);
+			$deadrealm->setActive(true);
+			$this->history->logEvent(
+				$deadrealm,
+				'event.realm.restored',
+				array('%link-realm%'=>$realm->getID(), '%link-realm%'=>$deadrealm->getId(), '%link-character%'=>$newruler->getId()),
+				History::ULTRA, true
+			);
+		}
+	}
 
 	public function removeRulerLiege(Realm $realm, Character $newruler) {
 		if ($liege = $newruler->getLiege()) {

--- a/src/BM2/SiteBundle/Service/RealmManager.php
+++ b/src/BM2/SiteBundle/Service/RealmManager.php
@@ -211,7 +211,7 @@ class RealmManager {
 		$this->removeRulerLiege($realm, $newruler);
 	}
 	
-	public function restoreSubRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
+/*	public function restoreSubRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
 		//this will allow superior realms to restore dead sub-realms --Andrew
 		if ($deadrealm->getActive() == false && $deadrealm->getSuperior()==$realm) {
 			$this->makeRuler($deadrealm, $newruler);
@@ -224,6 +224,7 @@ class RealmManager {
 			);
 		}
 	}
+*/
 
 	public function removeRulerLiege(Realm $realm, Character $newruler) {
 		if ($liege = $newruler->getLiege()) {

--- a/src/BM2/SiteBundle/Service/RealmManager.php
+++ b/src/BM2/SiteBundle/Service/RealmManager.php
@@ -214,7 +214,7 @@ class RealmManager {
 	public function restoreRealm(Realm $realm, Realm $deadrealm, Character $newruler) {
 		//this will allow superior realms to restore dead sub-realms --Andrew
 		if ($deadrealm->getActive() == false && $deadrealm->getSuperior()==$realm) {
-			$this->makeRuler($realm=$deadrealm, $newruler);
+			$this->makeRuler($deadrealm, $newruler);
 			$deadrealm->setActive(true);
 			$this->history->logEvent(
 				$deadrealm,

--- a/src/BM2/SiteBundle/Service/UserManager.php
+++ b/src/BM2/SiteBundle/Service/UserManager.php
@@ -6,7 +6,7 @@ use BM2\SiteBundle\Entity\User;
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\UserBundle\Doctrine\UserManager as FosUserManager;
 use FOS\UserBundle\Util\CanonicalizerInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use FOS\UserBundle\Util\PasswordUpdaterInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -20,7 +20,7 @@ class UserManager extends FosUserManager {
 	 * @param ObjectManager $om
 	 */
 	public function __construct(ObjectManager $om, $class, EncoderFactoryInterface $encoderFactory, CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer) {
-		parent::__construct($encoderFactory, $usernameCanonicalizer, $emailCanonicalizer, $om, $class);
+		parent::__construct($passwordUpdater, $usernameCanonicalizer, $emailCanonicalizer, $om, $class);
 	}
 
 	/**
@@ -53,7 +53,7 @@ class UserManager extends FosUserManager {
 		$user->setCredits(0);
 		$user->setVipStatus(0);
 		$user->setRestricted(false);
-		// new users subscription is 30-days, as in the old trial, but mostly because our payment interval is monthyl for them
+		// new users subscription is 30-days, as in the old trial, but mostly because our payment interval is monthly for them
 		$until = new \DateTime("now");
 		$until->add(new \DateInterval('P30D'));
 		$user->setAccountLevel(10)->setPaidUntil($until);

--- a/src/BM2/SiteBundle/Service/UserManager.php
+++ b/src/BM2/SiteBundle/Service/UserManager.php
@@ -19,8 +19,8 @@ class UserManager extends FosUserManager {
 	/**
 	 * @param ObjectManager $om
 	 */
-	public function __construct(ObjectManager $om, $class, EncoderFactoryInterface $encoderFactory, CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer) {
-		parent::__construct($passwordUpdater, $usernameCanonicalizer, $emailCanonicalizer, $om, $class);
+	public function __construct(ObjectManager $om, $class, PasswordUpdaterInterface $passwordUpdater, CanonicalizerInterface $canonicalFieldsUpdater) {
+		parent::__construct($passwordUpdater, $canonicalFieldsUpdater, $om, $class);
 	}
 
 	/**

--- a/src/BM2/SiteBundle/Service/UserManager.php
+++ b/src/BM2/SiteBundle/Service/UserManager.php
@@ -5,7 +5,7 @@ namespace BM2\SiteBundle\Service;
 use BM2\SiteBundle\Entity\User;
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\UserBundle\Doctrine\UserManager as FosUserManager;
-use FOS\UserBundle\Util\CanonicalizerInterface;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
 use FOS\UserBundle\Util\PasswordUpdaterInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -19,7 +19,7 @@ class UserManager extends FosUserManager {
 	/**
 	 * @param ObjectManager $om
 	 */
-	public function __construct(ObjectManager $om, $class, PasswordUpdaterInterface $passwordUpdater, CanonicalizerInterface $canonicalFieldsUpdater) {
+	public function __construct(ObjectManager $om, $class, PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater) {
 		parent::__construct($passwordUpdater, $canonicalFieldsUpdater, $om, $class);
 	}
 

--- a/src/BM2/SiteBundle/Twig/AppStateExtension.php
+++ b/src/BM2/SiteBundle/Twig/AppStateExtension.php
@@ -5,7 +5,7 @@ namespace BM2\SiteBundle\Twig;
 use BM2\SiteBundle\Service\AppState;
 
 
-class AppStateExtension extends \Twig_Extension {
+class AppStateExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface {
 	protected $appState;
 
 	public function __construct(AppState $appState) {

--- a/src/BM2/SiteBundle/Twig/DispatcherExtension.php
+++ b/src/BM2/SiteBundle/Twig/DispatcherExtension.php
@@ -5,7 +5,7 @@ namespace BM2\SiteBundle\Twig;
 use BM2\SiteBundle\Service\Dispatcher;
 
 
-class DispatcherExtension extends \Twig_Extension {
+class DispatcherExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface {
     protected $dispatcher;
 
     public function __construct(Dispatcher $dispatcher) {

--- a/src/BM2/SiteBundle/Twig/LinksExtension.php
+++ b/src/BM2/SiteBundle/Twig/LinksExtension.php
@@ -85,6 +85,7 @@ class LinksExtension extends \Twig_Extension {
 				case 'war':
 					$type = 'War';
 					break;
+				case 'n':
 				case 'news':
 				case 'newspaper':
 				case 'newsedition':
@@ -97,11 +98,15 @@ class LinksExtension extends \Twig_Extension {
 			}
 			$entity = $this->em->getRepository('BM2SiteBundle:'.$type)->find($id);
 			if ($entity) {
-				$url = $this->generator->generate($this->getLink($type), array('id' => $id));
-				if ($type == 'NewsEdition') {
-					$name = $entity->getPaper()->getName();
+				if ($type != 'NewsEdition') {
+					$url = $this->generator->generate($this->getLink($type), array('id' => $id));
 				} else {
+					$url = $this->generator->generate($this->getLink($type), array('edition' => $id));
+				}
+				if ($type != 'NewsEdition') {
 					$name = $entity->getName();
+				} else {
+					$name = $entity->getPaper()->getName();
 				}
 				$link .= '<a href="'.$url.'">'.$name.'</a>';
 			} else {
@@ -215,6 +220,10 @@ class LinksExtension extends \Twig_Extension {
 			case 'War':
 				$id = $entity->getId();
 				$name = $entity->getSummary();
+				break;
+			case 'NewsEdition':
+				$id = $entity->getId();
+				$name = $entity->getPaper->getName();
 				break;
 			default:
 				$id = $entity->getId();

--- a/src/BM2/SiteBundle/Twig/LinksExtension.php
+++ b/src/BM2/SiteBundle/Twig/LinksExtension.php
@@ -72,10 +72,11 @@ class LinksExtension extends \Twig_Extension {
 				case 'vote':
 					$type = 'Election';
 					break;
-				case 'i':
-				case 'item':
-					$type = 'Item';
-					break;
+#These presently do not actually reference anything and using them will error out an entire conversation for all users.
+#				case 'i':
+#				case 'item':
+#					$type = 'Item';
+#					break;
 				case 'a':
 				case 'artifact':
 					$type = 'Artifact';

--- a/src/BM2/SiteBundle/Twig/LinksExtension.php
+++ b/src/BM2/SiteBundle/Twig/LinksExtension.php
@@ -85,13 +85,24 @@ class LinksExtension extends \Twig_Extension {
 				case 'war':
 					$type = 'War';
 					break;
+				case 'news':
+				case 'newspaper':
+				case 'newsedition':
+				case 'edition':
+				case 'pub':
+				case 'publication':
+					$type = 'NewsEdition';
 				default:
 					return "[<em>invalid reference</em>]";
 			}
 			$entity = $this->em->getRepository('BM2SiteBundle:'.$type)->find($id);
 			if ($entity) {
 				$url = $this->generator->generate($this->getLink($type), array('id' => $id));
-				$name = $entity->getName();
+				if ($type == 'NewsEdition') {
+					$name = $entity->getPaper()->getName();
+				} else {
+					$name = $entity->getName();
+				}
 				$link .= '<a href="'.$url.'">'.$name.'</a>';
 			} else {
 				$link = "[<em>invalid reference</em>]";
@@ -140,6 +151,7 @@ class LinksExtension extends \Twig_Extension {
 			case 'quest':				return 'bm2_site_quests_details';
 			case 'artifact':			return 'bm2_site_artifacts_details';
 			case 'war':					return 'bm2_site_war_view';
+			case 'newsedition':		return 'bm2_site_news_read';
 		}
 		return 'invalid link entity "'.$name.'", this should never happen!';
 	}

--- a/src/BM2/SiteBundle/Twig/LinksExtension.php
+++ b/src/BM2/SiteBundle/Twig/LinksExtension.php
@@ -93,6 +93,13 @@ class LinksExtension extends \Twig_Extension {
 				case 'pub':
 				case 'publication':
 					$type = 'NewsEdition';
+					break;
+				case 'pos':
+				case 'position':
+				case 'realmpos':
+				case 'realmposition':
+					$type = 'RealmPosition';
+					break;
 				default:
 					return "[<em>invalid reference</em>]";
 			}


### PR DESCRIPTION
This is... 4 completely new methods, 1 new form, 1 new html twig, and 3 updated translation files.

And this is also why I'd like to have a test server, so I could try out more interesting things than this without accidentally, catastrophically breaking something.

This will allow rulers to restore any abandoned direct subrealm. I thought about allowing ANY subrealm of their realm, but that can 1) step on the toes of subrulers, and is 2) needless work because they can just recreate the chain from their realm down to whatever barony makes them happy.

Assuming this is all good, it also lays the groundwork for how you'd allow realms to be recreated, as well.
